### PR TITLE
[ADD] 하트 아이템 먹었을 때 색깔 변화 추가

### DIFF
--- a/.idea/runConfigurations/Run.xml
+++ b/.idea/runConfigurations/Run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="corretto-18" />
+    <option name="ALTERNATIVE_JRE_PATH" value="11" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="engine.Core" />
-    <module name="thu-space-invader" />
+    <module name="thu-space-invaders" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/src/entity/Entity.java
+++ b/src/entity/Entity.java
@@ -57,6 +57,12 @@ public class Entity {
 		return color;
 	}
 
+	// 아이템 먹었을 때 색깔 변할 수 있게 메서드 추가 
+	// Add a method so that the color changes when you eat an item
+	public final void setColor(Color color) {
+		this.color = color;
+	}
+	
 	/**
 	 * Getter for the X axis position of the entity.
 	 * 

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -1,5 +1,6 @@
 package screen;
 import java.util.Random;
+import java.awt.Color;
 import java.awt.event.KeyEvent;
 import java.util.HashSet;
 import java.util.Set;
@@ -395,6 +396,10 @@ public class GameScreen extends Screen {
 						this.lives++;
 						this.logger.info("Acquire a item_lifePoint," + this.lives + " lives remaining.");
 					}
+
+					// 아이템 먹었을 때 색깔 변하는 효과
+					this.ship.setColor(Color.YELLOW); // 임시로 노란색
+
 				}
 				if (per == 1) {
 					int shootingSpeed = (int) (ship.getSHOOTING_INTERVAL() * 0.7);


### PR DESCRIPTION
1. Entitiy.java에 setColor() 메서드를 추가해서 entitiy의 색깔을 수정할 수 있게 함.
2.GameScreen.java에 있는 manageCollisionsItem() 메서드 안에 하트 아이템을 먹었을 때 setColor 메서드를 불러옴.

하트 아이템을 먹었을 때 그것을 명확히 표현할 색깔이 초록색인데, 원래 ship의 색깔이라서 고민해봐야 함.
몇 초 후에 원래 색으로 변하게 구현하는 게 잘 안됨. 시간 측정하는 동안 게임이 멈추는 현상이 있음.
